### PR TITLE
Fix filenames of download scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ pip install -e .
 ### Download datasets
 
 ```
-bash download_datasets.sh
+bash download_all_datasets.sh
 ``` 
 
 
 ### Download pretrained models
 
 ``` 
-bash download_models.sh
+bash download_all_models.sh
 ```
     
 


### PR DESCRIPTION
Fix incorrect script filenames in documentation

This pull request updates the README file to correct the filenames of the scripts used for downloading datasets and models. The changes ensure that the documentation matches the actual script names, improving usability and preventing confusion.

Changes made:
- Renamed `download_datasets.sh` to `download_all_datasets.sh` 
- Renamed `download_models.sh` to `download_all_models.sh`