### PR TITLE
Fix flash attention bug and add cpu-only inference and evaluation to get the same results.

### DIFF
--- a/RNAformer/module/axial_attention.py
+++ b/RNAformer/module/axial_attention.py
@@ -150,7 +150,7 @@ class Attention2d(nn.Module):
         attn_weights = torch.matmul(query, key)
 
         if self.softmax_scale:
-            attn_weights = attn_weights / self.softmax_scale.to(pair_act.device)
+            attn_weights *= self.softmax_scale.to(pair_act.device)
 
         if attention_mask is not None:
             attention_mask = attention_mask[:, :, None, None, :]
@@ -267,7 +267,7 @@ class AxialAttention(nn.Module):
         attn_weights = torch.matmul(query, key)
 
         if softmax_scale:
-            attn_weights = attn_weights / softmax_scale
+            attn_weights *= softmax_scale
 
         if attention_mask is not None:
             attention_mask = attention_mask[:, :, None, None, :]

--- a/RNAformer/module/axial_attention.py
+++ b/RNAformer/module/axial_attention.py
@@ -7,8 +7,15 @@ import warnings
 import torch.nn.functional as F
 from einops import rearrange, repeat
 
-from flash_attn.bert_padding import unpad_input, pad_input
-from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
+def is_package_installed(package_name):
+    import pkg_resources
+    installed_packages = {pkg.key for pkg in pkg_resources.working_set}
+    return package_name in installed_packages
+
+if is_package_installed('flash_attn'):
+    from flash_attn.bert_padding import unpad_input, pad_input
+    from flash_attn.flash_attn_interface import flash_attn_varlen_qkvpacked_func
+    
 from rotary_embedding_torch import apply_rotary_emb, RotaryEmbedding, broadcat
 
 
@@ -170,7 +177,7 @@ class TriangleAttention(nn.Module):
 
         self.input_norm = nn.LayerNorm(model_dim, eps=1e-6)
 
-        if flash_attn:
+        if flash_attn and is_package_installed('flash_attn'):
             self.attn = FlashAttention2d(model_dim, num_head, softmax_scale, zero_init, use_bias,
                                          initializer_range, n_layers)
         else:
@@ -296,7 +303,7 @@ class AxialAttention(nn.Module):
         query = apply_rotary_emb(freqs, query)
         key = apply_rotary_emb(freqs, key)
 
-        if self.use_flash_attn:
+        if self.use_flash_attn and is_package_installed('flash_attn'):
             qkv = torch.cat((query, key, value), dim=-1)
             not_attention_mask = torch.logical_not(pair_mask)
 


### PR DESCRIPTION
Fixed attention implementation to get the same performance with flash-attn=False/True.

Automatically checks for flash-attn package and also device to be able to run inference and evaluation without a GPU or flash attention installed.